### PR TITLE
Make `eslint-plugin-react` an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,20 @@ npm install eslint-config-mixmax --save-dev
 
 Install this config's peer dependencies if you haven't already:
 ```sh
-yarn add -D "babel-eslint@^7.2.3" "eslint@>=3" "eslint-plugin-react@^7.1.0"
+yarn add -D "babel-eslint@^7.2.3" "eslint@>=3"
 ```
 or
 ```sh
-npm install --save-dev "babel-eslint@^7.2.3" "eslint@>=3" "eslint-plugin-react@^7.1.0"
+npm install --save-dev "babel-eslint@^7.2.3" "eslint@>=3"
+```
+
+If you'll be using the `browser` configs, make sure to install the optional `eslint-plugin-react` dependency.
+```sh
+yarn add -D "eslint-plugin-react@^7.1.0"
+```
+or
+```sh
+npm install --save-dev "eslint-plugin-react@^7.1.0"
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "url": "https://github.com/mixmaxhq/eslint-config-mixmax/issues"
   },
   "homepage": "https://github.com/mixmaxhq/eslint-config-mixmax#readme",
-  "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": ">= 3",
+  "optionalDependencies": {
     "eslint-plugin-react": "^7.1.0"
   },
-  "devDependencies": {}
+  "peerDependencies": {
+    "babel-eslint": "^7.2.3",
+    "eslint": ">= 3"
+  }
 }


### PR DESCRIPTION
Projects that do not use our `browser` configs will not need this dependency, so we don't want to
require it via `peerDependencies`.