### PR TITLE
jsx-quotes prefer-single

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   extends: 'eslint:recommended',
   rules: {
     'arrow-parens': ['error', 'always'],
+    'jsx-quotes': ['error', 'prefer-single'],
     'no-mixed-operators': ['error', {'groups': [['&&','||']]}],
     indent: ['error', 2, {
       SwitchCase: 1


### PR DESCRIPTION
From [Chuy's review](https://github.com/mixmaxhq/app/pull/2441#pullrequestreview-74870631) realized we are not checking for single vs double quote in JSX properties.

From [code-styles](https://github.com/mixmaxhq/code-styles/blob/master/README.md#js) looks like we want this.

| Use single quotes in all JS code, unless you have a string that has a single quote in it, in which case you can use double quotes.

Here's what the changes look like in an [app PR](https://github.com/mixmaxhq/app/pull/2580)
