### PR TITLE
Adds no-throw-literal rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,5 +55,8 @@ module.exports = {
 
     // Error when we use parseInt incorrectly or without the radix parameter.
     'radix': ['error', 'always'],
+
+    // Only allow throwing Error objects.
+    'no-throw-literal': ['error']
   }
 };


### PR DESCRIPTION
Tested by linking:
```
[~/ (ryan/test)]$ npm run lint

> test@0.0.1 lint /Users/rfreebern
> eslint . --ext '.js, .jsx'


/Users/rfreebern/test.js
  164:5  error  Expected an object to be thrown  no-throw-literal
  169:5  error  Expected an object to be thrown  no-throw-literal
  174:5  error  Expected an object to be thrown  no-throw-literal

✖ 3 problems (3 errors, 0 warnings)
```
😅 