### PR TITLE
Add disable require atomic option

### DIFF
--- a/node/disable-require-atomic.js
+++ b/node/disable-require-atomic.js
@@ -1,0 +1,9 @@
+module.exports = {
+  rules: {
+    /* Although this rule can provide some useful warning when doing assignments inline with
+     * async/await (i.e x += await getX()), it's extremely aggressive in assuming out of scope
+     * variables should not be reassigned. There's more info in this issue:
+     * https://github.com/eslint/eslint/issues/11899 */
+    'require-atomic-updates': 'off'
+  }
+};


### PR DESCRIPTION
Looks like the `require-atomic-update` option is a bit overzealous. I ran into the same issue in the salesforce module.