### PR TITLE
Remove consistent-return rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,9 +58,5 @@ module.exports = {
 
     // Only allow throwing Error objects.
     'no-throw-literal': ['error'],
-
-    // Require consistent return values (either always or never specifying values) so we don't
-    // rely on implicit returns when return booleans or undefined.
-    'consistent-return': ['error', {treatUndefinedAsUnspecified: true}],
   }
 };


### PR DESCRIPTION
This rule causes far more problems than it's worth, and ends up mucking with semantics of proper code. If there were a way to mark `return undefined` as an ambiguous expression, I think this would be a different matter. As it currently stands, this rule catches some occasional bugs but mostly causes pain.