### PR TITLE
feat: override babel config file sourceType

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -6,4 +6,12 @@ module.exports = {
     node: true,
   },
   extends: ['..', '../prettier'],
+  overrides: [
+    {
+      files: ['babel.config.js'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
This can get a bit tedious to always override the sourceType when using es module syntax in the rest of the codebase.