### PR TITLE
feat: specify react version for warning

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -21,4 +21,9 @@ module.exports = {
   rules: {
     'react/jsx-wrap-multilines': 2,
   },
+  settings: {
+    react: {
+      version: '16.3',
+    },
+  },
 };


### PR DESCRIPTION
We're currently seeing warnings regarding the configuration of the eslint-plugin-react package, and adding the setting downstream doesn't seem to work. Adding it here clears the warning in other codebases!