### PR TITLE
feat: ignore flow-typed/npm in flow config

### DIFF
--- a/flow/index.js
+++ b/flow/index.js
@@ -1,5 +1,8 @@
 module.exports = {
   parser: 'babel-eslint',
+  // Ignore these files as they are dependencies and their noncompliance with our arbitrary rules
+  // should not prevent their use.
+  ignorePatterns: ['flow-typed/npm/**'],
   plugins: [
     // Allows correct parsing of flow annotated files.
     'flowtype',


### PR DESCRIPTION
This can cause problems with `flow-typed` distributed files.