### PR TITLE
feat: bump node ecmaVersion to support 10.x features

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 2018, // Node 8.
+    ecmaVersion: 2020, // Node 11.
   },
   env: {
     node: true,


### PR DESCRIPTION
A little hesitant to do this since 10.x doesn't support every es2020 feature per https://node.green/#ES2020, but I think the unsupported features are unlikely to be used (and will fail fast anyway).