### PR TITLE
docs(readme): remove old changelog from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,3 @@ immediately breaking our projects I’ve deferred this till later.
 
 This repository should probably document whatever styles we end up adopting, i.e. we should migrate
 https://github.com/mixmaxhq/code-styles#js to here.
-
-## Changelog
-
-* 1.0.0 Add flow support and *BREAKING* upgrade minimum eslint version to `4.14.0`.
-* 0.7.0 Enforce `arrow-parens` with error.
-* 0.6.0 Add `ava` config
-* 0.5.0 Globalize `analytics` in `browser` configs.
-* 0.4.2 Make `babel-eslint` an optional dependency.
-* 0.4.1 Make `eslint-plugin-react` an optional dependency.
-* 0.4.0 Add `browser` and `browser/spec` configs.


### PR DESCRIPTION

#### Changes Made
remove old changelog from readme

Since it's now in a separate file.

#### Potential Risks
None.

#### Test Plan
None.

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
