### PR TITLE
fix: invalid ecmascript bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm install eslint-config-mixmax --save-dev
 
 Install this config's peer dependencies if you haven't already:
 ```sh
-npm install -D "eslint@>=4.14.0"
+npm install -D "eslint@>=6.2.0"
 ```
 or
 ```sh
-npm install --save-dev "eslint@>=4.14.0"
+npm install --save-dev "eslint@>=6.2.0"
 ```
 
 If you'll be using the `browser` configs, make sure to install the optional `eslint-plugin-react` and `babel-eslint` dependencies.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-react": "^7.14.2"
   },
   "peerDependencies": {
-    "eslint": ">=6.0.1"
+    "eslint": ">=6.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",


### PR DESCRIPTION
Jira: found upgrading in app https://github.com/mixmaxhq/app/pull/10375.

#### Changes Made
es2020 that we upgraded to in https://github.com/mixmaxhq/eslint-config-mixmax/pull/50 requires eslint 6.2.0 or greater (https://github.com/eslint/eslint/commit/fee6acbe13cecd4c028e681e185fc6a6d6ba9452)

#### Potential Risks
Low. This is bumping a dependency that we already use in many of our other codebases.

#### Test Plan
npm install this module. It should install eslint>=6.2.0 as a peer dependency.

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
