### PR TITLE
fix: Mixmax internal imports misordered 

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = {
         alphabetize: { order: 'asc', caseInsensitive: true },
         'newlines-between': 'always',
         pathGroups: [
-          { pattern: '@mixmaxhq/**/*', group: 'external', position: 'after' },
+          { pattern: '@mixmaxhq/**', group: 'external', position: 'after' },
           { pattern: '{,~}/utils/**', group: 'internal', position: 'before' },
           { pattern: '{,~}/**', group: 'internal' },
         ],

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = {
         alphabetize: { order: 'asc', caseInsensitive: true },
         'newlines-between': 'always',
         pathGroups: [
-          { pattern: '@mixmaxhq/*', group: 'external', position: 'after' },
+          { pattern: '@mixmaxhq/**/*', group: 'external', position: 'after' },
           { pattern: '{,~}/utils/**', group: 'internal', position: 'before' },
           { pattern: '{,~}/**', group: 'internal' },
         ],


### PR DESCRIPTION
#### Changes Made
Fix pattern used to match internal Mixmax packages with subfolders. 
The previous pattern was making the imports with nested folders to be at the top of the file, on top of external packages.

Before
![Screen Shot 2021-01-20 at 21 19 55](https://user-images.githubusercontent.com/2932468/105256886-65a3f300-5b65-11eb-8225-1f36df14ec4e.png)

After
![Screen Shot 2021-01-20 at 21 20 08](https://user-images.githubusercontent.com/2932468/105256892-676db680-5b65-11eb-9d7c-93fce1f48d5a.png)

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->
Low. This should be easily upgraded by eslint's automated script. 

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->
