### PR TITLE
feat: add eslint-plugin-react-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,46 +10,29 @@ Later it should probably enforce [our code styles](https://github.com/mixmaxhq/c
 npm install -D eslint-config-mixmax
 ```
 
-or
-
-```sh
-npm install eslint-config-mixmax --save-dev
-```
-
 Install this config's peer dependencies if you haven't already:
 
 ```sh
 npm install -D "eslint@>=7.18.0"
 ```
+### Using browser config
 
-or
+If you'll be using the `browser` configs, make sure to install the following dependencies:
+- `eslint-plugin-react`
+- `eslint-plugin-react-hooks`
+- `babel-eslint`
 
-```sh
-npm install --save-dev "eslint@>=7.18.0"
-```
-
-If you'll be using the `browser` configs, make sure to install the optional `eslint-plugin-react` and `babel-eslint` dependencies.
-
-```sh
-npm install -D "eslint-plugin-react@^7.1.0" "babel-eslint@^8.2.1"
-```
-
-or
 
 ```sh
-npm install --save-dev "eslint-plugin-react@^7.1.0" "babel-eslint@^8.2.1"
+npm install -D "eslint-plugin-react@^7.23.1" "babel-eslint@^10.0.2" "eslint-plugin-react-hooks@^4.2.0"
 ```
+
+### Using Flow config
 
 If you'll be using the `flow` configs, make sure to install the optional `eslint-plugin-flowtype` and `babel-eslint` dependencies.
 
 ```sh
-npm install -D "eslint-plugin-flowtype@^2.41.0" "babel-eslint@^8.2.1"
-```
-
-or
-
-```sh
-npm install --save-dev "eslint-plugin-flowtype@^2.41.0" "babel-eslint@^8.2.1"
+npm install -D "eslint-plugin-flowtype@^3.11.1" "babel-eslint@^10.0.2"
 ```
 
 ## Usage

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['..', 'plugin:react/recommended'],
+  extends: ['..', 'plugin:react/recommended', 'plugin:react-hooks/recommended'],
   parser: 'babel-eslint',
   parserOptions: {
     ecmaFeatures: {
@@ -23,5 +23,8 @@ module.exports = {
 
     // enforce the usage of either <React.Fragment> or <Fragment> instead of the shorthand <>
     'react/jsx-fragments': ['error', 'element'],
+
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8532,6 +8532,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "optional": true
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.0",
-    "eslint-plugin-react": "^7.23.1"
+    "eslint-plugin-react": "^7.23.1",
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "peerDependencies": {
     "eslint": ">=7.18.0"


### PR DESCRIPTION
#### Changes Made
This PR adds the plugin [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) to the browser config, using the default settings. 
This plugin enforces the [Rules of Hooks](https://reactjs.org/docs/hooks-rules.html).

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->
You may have to take a closer look at the files that violate the rules because they can't be automatically fixed.