### PR TITLE
fix: fix react fragment rule config

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -20,5 +20,8 @@ module.exports = {
   },
   rules: {
     'react/jsx-wrap-multilines': 2,
+
+    // enforce the usage of either <React.Fragment> or <Fragment> instead of the shorthand <>
+    'react/jsx-fragments': ['error', 'element'],
   },
 };

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = {
     es6: true,
   },
   extends: 'eslint:recommended',
-  plugins: ['import', 'react'],
+  plugins: ['import'],
   rules: {
     'arrow-parens': ['error', 'always'],
     'prefer-const': ['error'],
@@ -114,9 +114,6 @@ module.exports = {
 
     // Also sort the named imports _within_ an import statement.
     'sort-imports': ['warn', { ignoreDeclarationSort: true }],
-
-    // enforce the usage of either <React.Fragment> or <Fragment> instead of the shorthand <>
-    'react/jsx-fragments': ['error', 'element'],
   },
   overrides: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6426,7 +6426,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
       "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -6438,7 +6438,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -6462,7 +6462,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -6473,19 +6473,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -6495,13 +6495,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -6513,7 +6513,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -6523,7 +6523,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -6747,7 +6747,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -7876,7 +7876,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -8384,7 +8384,7 @@
       "version": "7.23.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.23.1.tgz",
       "integrity": "sha512-MvFGhZjI8Z4HusajmSw0ougGrq3Gs4vT/0WgwksZgf5RrLrRa2oYAw56okU4tZJl8+j7IYNuTM+2RnFEuTSdRQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
@@ -8404,7 +8404,7 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
           "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
@@ -8417,7 +8417,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -8441,7 +8441,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -8452,19 +8452,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -8474,13 +8474,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -8492,7 +8492,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
           "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
@@ -8504,7 +8504,7 @@
           "version": "2.0.0-next.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
           "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-core-module": "^2.2.0",
             "path-parse": "^1.0.6"
@@ -8514,7 +8514,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -8524,7 +8524,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -9225,7 +9225,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -9236,7 +9236,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -9727,7 +9727,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "optional": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -10219,7 +10219,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -10271,13 +10271,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
       "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==",
-      "dev": true
+      "optional": true
     },
     "is-boolean-object": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
       "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -10298,7 +10298,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
       "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -10384,7 +10383,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
-      "dev": true
+      "optional": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -10396,7 +10395,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
       "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
+      "optional": true
     },
     "is-obj": {
       "version": "1.0.1",
@@ -10456,7 +10455,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "optional": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -10527,7 +10526,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "optional": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -10594,7 +10593,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
       "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
@@ -10604,7 +10603,7 @@
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
           "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3",
@@ -10617,7 +10616,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -10641,7 +10640,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -10652,19 +10651,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -10674,13 +10673,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -10692,7 +10691,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -10702,7 +10701,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -10860,7 +10859,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -14727,7 +14726,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "optional": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -14802,7 +14801,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.3.tgz",
       "integrity": "sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -14814,7 +14813,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -14838,7 +14837,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14849,19 +14848,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -14871,13 +14870,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -14889,7 +14888,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -14899,7 +14898,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -14911,7 +14910,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.4.tgz",
       "integrity": "sha512-EsFBshs5RUUpQEY1D4q/m59kMfz4YJvxuNCJcv/jWwOJr34EaVnG11ZrZa0UHB3wnzV1wx8m58T4hQL8IuNXlQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -14923,7 +14922,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -14947,7 +14946,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -14958,19 +14957,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -14980,13 +14979,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -14998,7 +14997,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -15008,7 +15007,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -15389,7 +15388,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15448,7 +15447,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "optional": true
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -15534,7 +15533,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
       "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -16234,7 +16233,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -16245,7 +16244,7 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -16547,7 +16546,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
       "integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -16562,7 +16561,7 @@
           "version": "1.18.0",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
           "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -16586,7 +16585,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -16597,19 +16596,19 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-callable": {
           "version": "1.2.3",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
           "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
-          "dev": true
+          "optional": true
         },
         "is-regex": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
           "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-symbols": "^1.0.1"
@@ -16619,13 +16618,13 @@
           "version": "1.9.0",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
           "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
-          "dev": true
+          "optional": true
         },
         "object.assign": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
           "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.0",
             "define-properties": "^1.1.3",
@@ -16637,7 +16636,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
           "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -16647,7 +16646,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
           "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
@@ -17199,7 +17198,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -17211,7 +17210,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -17358,7 +17357,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -17371,13 +17370,13 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
           "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "optional": true
         },
         "is-symbol": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-          "dev": true,
+          "optional": true,
           "requires": {
             "has-symbols": "^1.0.1"
           }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-flowtype": "^3.11.1",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-prettier": "^3.1.0"
+    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-react": "^7.23.1"
   },
   "peerDependencies": {
     "eslint": ">=7.18.0"
@@ -54,7 +55,6 @@
     "@mixmaxhq/semantic-release-config": "^2.0.1",
     "cz-conventional-changelog": "^3.0.2",
     "eslint": "^6.6.0",
-    "eslint-plugin-react": "^7.23.1",
     "prettier": "^1.19.1",
     "semantic-release": "^17.2.3"
   },


### PR DESCRIPTION
#### Changes Made
Move the react-fragment config to the browser env, fixing errors caused in node envs introduced in #71 
Also moves the plugin back to the optionalDeps.

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->
That it doesn't fix the issue or the rule is not being correctly applied in web apps.

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->

- [ ] run npm ci in this repo;
- [ ] use npm link this package to your repo; 
- [ ] run `npx eslint  --ext .js path/to/scripts`; 
- [ ] ensure it runs correctly with no dependency errors

I've linked it with Mixmax's app repository and it's still applying the eslint rule introduced by #71.
I have also tested in a backend-only repo and it now doesn't throw a dependency error.