### PR TITLE
feat: ignore order of imports for test files

### DIFF
--- a/typescript/index.js
+++ b/typescript/index.js
@@ -23,4 +23,13 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['**/*.test.ts'],
+      rules: {
+        'import/first': 'off',
+        'import/order': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Sometimes, for the mocks to work it is important
to import dependencies in a specific order.

#### Changes Made
* Ignore order linting for imports

#### Potential Risks
<!--- What can go wrong with this change? How will these changes affect adjacent code/features? How will we handle any adverse issues? --->

#### Test Plan
<!--- How do we know this PR does what it's supposed to do? How do we ensure that adjacent code/features are still working? How do we evaluate the performance implications of this PR?--->

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
