### PR TITLE
fix: allow some unused varables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "4.15.0",
+      "version": "4.17.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^8.3.5",

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -19,7 +19,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
-        argsIgnorePattern: 'next',
+        argsIgnorePattern: '^_|^next$',
       },
     ],
   },


### PR DESCRIPTION
#### Changes Made
We should allow underscore prefixed unused variables - the same way typescript does.

#### Potential Risks
small. i found this while updating @mixmaxhq/zoom and seems like the appropriate way to handle it.

#### Test Plan
link, test, deploy.

#### Checklist
- [n/a] I've increased test coverage
- [x] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
