### PR TITLE
fix: make addRegexRuleName idempotent to support multi-load via import-fresh

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 const { addRegexRuleName } = require('eslint-plugin-regex');
-addRegexRuleName('invalid-product-id-parsing');
+// addRegexRuleName throws if the rule name is already registered. ESLint can
+// load this config more than once per lint run (via import-fresh, which
+// bypasses the Node.js require cache — notably when an overrides[] block in
+// a child config uses `extends`, as typescript/index.js does). Swallow the
+// redefine error so repeated loads remain a no-op.
+try {
+  addRegexRuleName('invalid-product-id-parsing');
+} catch (err) {
+  if (!/already defined/i.test(err && err.message)) throw err;
+}
 
 const ATTEMPT_AT_PARSING_PRODUCT_IDS = /('mixmax-product-ids'\)|productIds?)[\.\[]|for.* (of|in) productIds?|(match|test)\s*\(\s*(productIds?|.*'mixmax-product-ids')/i;
 


### PR DESCRIPTION
## Summary

Fixes a critical regression introduced in v6.0.0 that breaks every consumer using `mixmax/typescript` + `eslint-plugin-regex`.

## The bug

After upgrading to v6.0.0, consumers hit:

```
Error: Cannot read config file: node_modules/eslint-config-mixmax/index.js
Error: "invalid-product-id-parsing" already defined as eslint-plugin-regex rule name
Referenced from: node_modules/eslint-config-mixmax/typescript/index.js
    at addRegexRuleName (node_modules/eslint-plugin-regex/lib/index.js:12:15)
    at Object.<anonymous> (node_modules/eslint-config-mixmax/index.js:2:1)
```

## Root cause

`index.js` has a non-idempotent side-effect at load time:

```js
const { addRegexRuleName } = require('eslint-plugin-regex');
addRegexRuleName('invalid-product-id-parsing');
```

ESLint loads config files via `import-fresh`, which **bypasses the Node.js require cache**. `index.js` gets re-executed every time a config that transitively extends it is resolved.

In v5 this happened exactly once per lint run. In v6, the new `overrides[]` block in `typescript/index.js` has its own `extends: ['plugin:@vitest/legacy-recommended']`, which causes ESLint to re-resolve the parent config chain during override processing — so `index.js` gets re-executed a second time. The second `addRegexRuleName` call throws because the rule name is already registered.

## The fix

Wrap the registration in a try/catch that only swallows the "already defined" error. Any other error still propagates. Result: repeated loads become a no-op; real errors still surface.

```js
try {
  addRegexRuleName('invalid-product-id-parsing');
} catch (err) {
  if (!/already defined/i.test(err && err.message)) throw err;
}
```

## Verification

1. `npm run lint` in this repo still passes.
2. Patched `node_modules/eslint-config-mixmax/index.js` with this change inside **monorepo-billing** (which was hitting the regression after upgrading to v6.0.0) and re-ran `eslint` on several `.spec.ts` files — **0 errors**, vitest globals correctly recognized.

## Why a future release should pick this up fast

Every consumer upgrading from v5 to v6 will hit this on the first lint run. Once this merges and ships (v6.0.1), consumers can upgrade without the workaround.

## Test plan

- [ ] CI `checks / test` passes
- [ ] Merge and release v6.0.1
- [ ] Re-run eslint in monorepo-billing against real v6.0.1 from npm to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)